### PR TITLE
pvhome-#98: pulling delta-db image from dockerhub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,8 @@ services:
         
 
   delta-db:
-    build:
-      context: ./delta-table/docker/
-      dockerfile: Dockerfile
+    image: pontusvisiongdpr/pv-deltadb:latest
+
     container_name: node-pontus-jdbc-db-setup
 
     volumes:


### PR DESCRIPTION
Using pv image in order to speed up the CI/CD process